### PR TITLE
v0.7.0: Tuple return pattern, labeling system, SMLMData 0.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SMLMSim"
 uuid = "5a0a87e4-02d4-41f5-bf26-b8c94c784a04"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["klidke@unm.edu"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaSMLM.github.io/SMLMSim.jl/stable)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaSMLM.github.io/SMLMSim.jl/dev)
 [![Build Status](https://github.com/JuliaSMLM/SMLMSim.jl/workflows/CI/badge.svg)](https://github.com/JuliaSMLM/SMLMSim.jl/actions)
-[![Coverage](https://codecov.io/gh/JuliaSMLM/SMLMSim.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaSMLM/SMLMSim.jl)
+[![Coverage](https://codecov.io/gh/JuliaSMLM/SMLMSim.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/JuliaSMLM/SMLMSim.jl)
 
 ## Overview
 
@@ -86,6 +86,27 @@ Define spatial arrangements (see `Pattern` types like `Nmer2D`, `Line3D`, `unifo
 # Examples:
 nmer = Nmer2D(n=8, d=0.1)  # 8 molecules in a 100nm diameter circle
 line = Line3D(λ=5.0, endpoints=[(-1.0, 0.0, -0.5), (1.0, 0.0, 0.5)]) # 5 mols/μm
+```
+
+### Labeling
+
+Control how many fluorophores attach to each binding site (see `AbstractLabeling`).
+
+```julia
+# Default: exactly 1 fluorophore per site
+labeling = FixedLabeling()
+
+# Poisson-distributed (avg 1.5 per site)
+labeling = PoissonLabeling(1.5)
+
+# Binomial: 4 attachment points, 80% probability each
+labeling = BinomialLabeling(4, 0.8)
+
+# With labeling efficiency (90% of sites get labeled)
+labeling = PoissonLabeling(1.5; efficiency=0.9)
+
+# Use in simulation
+smld_noisy, info = simulate(params; pattern=Nmer2D(), labeling=PoissonLabeling(1.5))
 ```
 
 ### Molecules & Photophysics

--- a/api_overview.md
+++ b/api_overview.md
@@ -20,13 +20,14 @@ All simulations use consistent physical units:
 
 ## Type Hierarchy
 
-- `AbstractSim`: Base type for all simulation types
+- `AbstractSMLMConfig`: Base type for all config types (from SMLMData)
   - `SMLMSimParams`: Base type for simulation parameters
     - `StaticSMLMConfig`: Parameters for static SMLM simulation
     - `DiffusionSMLMConfig`: Parameters for diffusion simulation
 
-- `SimInfo`: Metadata and intermediate results from simulation functions
-- `ImageInfo`: Metadata from image generation functions
+- `AbstractSMLMInfo`: Base type for info structs (from SMLMData)
+  - `SimInfo`: Metadata and intermediate results from simulation functions
+  - `ImageInfo`: Metadata from image generation functions
 
 - `Pattern`: Base type for all molecular patterns
   - `Pattern2D`: Base type for 2D patterns
@@ -126,8 +127,8 @@ end
 Metadata and intermediate results from simulation functions. Returned as the second element of the tuple from `simulate()`.
 
 ```julia
-struct SimInfo
-    elapsed_s::Float64              # Wall-clock time in nanoseconds
+struct SimInfo <: AbstractSMLMInfo
+    elapsed_s::Float64              # Wall-clock time in seconds
     backend::Symbol                 # Computation backend (:cpu)
     device_id::Int                  # Device identifier (-1 for CPU)
     seed::Union{UInt64, Nothing}    # RNG seed for reproducibility
@@ -145,8 +146,8 @@ end
 Metadata from image generation functions. Returned as the second element of the tuple from `gen_images()` and `gen_image()`.
 
 ```julia
-struct ImageInfo
-    elapsed_s::Float64              # Wall-clock time in nanoseconds
+struct ImageInfo <: AbstractSMLMInfo
+    elapsed_s::Float64              # Wall-clock time in seconds
     backend::Symbol                 # Computation backend (:cpu)
     device_id::Int                  # Device identifier (-1 for CPU)
     frames_generated::Int           # Number of frames generated

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,6 +20,7 @@ makedocs(;
         "Home" => "index.md",
         "Core Components" => [
             "Patterns" => "core/patterns.md",
+            "Labeling" => "core/labeling.md",
             "Photophysics" => "core/photophysics.md",
             "Localization Uncertainty" => "core/noise.md"
         ],

--- a/docs/src/core/labeling.md
+++ b/docs/src/core/labeling.md
@@ -1,0 +1,110 @@
+```@meta
+CurrentModule = SMLMSim
+```
+
+# Labeling Strategies
+
+Labeling controls how many fluorophores attach to each binding site in a pattern. This is separate from photophysics — labeling determines *how many* fluorophores are placed, while [`Molecule`](@ref) types handle the *blinking kinetics* of each one.
+
+## Pipeline Position
+
+Labeling sits between pattern generation and photophysics in the simulation pipeline:
+
+```
+Pattern (geometry) → uniform2D/3D() → binding site coordinates
+  → apply_labeling() → fluorophore positions (one or more per site)
+  → kinetic_model() → blinking behavior per fluorophore
+  → apply_noise() → localization uncertainty
+```
+
+## Labeling Types
+
+All labeling types support an `efficiency` parameter (0 to 1) controlling the probability that a binding site gets labeled at all. This is applied *before* sampling the number of fluorophores.
+
+### FixedLabeling
+
+Deterministic: exactly `n` fluorophores per labeled site.
+
+```julia
+# Default: 1 fluorophore per site, 100% efficiency
+labeling = FixedLabeling()
+
+# 2 fluorophores per site, 90% of sites labeled
+labeling = FixedLabeling(2; efficiency=0.9)
+```
+
+### PoissonLabeling
+
+Poisson-distributed number of fluorophores per site. Useful when the labeling count varies stochastically (e.g., random antibody binding).
+
+```julia
+# Average 1.5 fluorophores per site
+labeling = PoissonLabeling(1.5)
+
+# Average 2.0 per site, 80% labeling efficiency
+labeling = PoissonLabeling(2.0; efficiency=0.8)
+```
+
+Note: with Poisson statistics, some sites may receive 0 fluorophores even when `efficiency=1.0`, especially for small mean values.
+
+### BinomialLabeling
+
+Binomial-distributed: each site has `n` potential attachment points, each occupied with probability `p`. Models scenarios like an antibody with multiple dye-conjugation sites.
+
+```julia
+# 4 attachment points, 80% occupancy each
+labeling = BinomialLabeling(4, 0.8)
+
+# Same, but only 90% of sites receive an antibody
+labeling = BinomialLabeling(4, 0.8; efficiency=0.9)
+```
+
+## Using Labeling in Simulations
+
+Pass a labeling strategy to `simulate()` via the `labeling` keyword:
+
+```julia
+params = StaticSMLMConfig(density=1.0, σ_psf=0.13)
+
+# Default (FixedLabeling with 1 fluorophore per site)
+smld_noisy, info = simulate(params; pattern=Nmer2D())
+
+# Poisson labeling
+smld_noisy, info = simulate(params; pattern=Nmer2D(), labeling=PoissonLabeling(1.5))
+
+# Binomial labeling with reduced efficiency
+smld_noisy, info = simulate(params;
+    pattern=Nmer2D(n=6, d=0.2),
+    labeling=BinomialLabeling(4, 0.8; efficiency=0.9)
+)
+```
+
+## Direct Usage with apply_labeling
+
+For custom workflows, use `apply_labeling` directly on binding site coordinates:
+
+```julia
+# Generate binding sites from a pattern distribution
+x, y, pattern_ids = uniform2D(1.0, Nmer2D(), 10.0, 10.0)
+
+# Apply labeling with pattern ID tracking
+(x_labeled, y_labeled), new_ids = apply_labeling((x, y), pattern_ids, PoissonLabeling(1.5))
+
+# Without pattern tracking (backward-compatible)
+x_labeled, y_labeled = apply_labeling((x, y), FixedLabeling(2))
+
+# Works with 3D coordinates
+x, y, z, pattern_ids = uniform3D(1.0, Nmer3D(), 10.0, 10.0)
+(x_labeled, y_labeled, z_labeled), new_ids = apply_labeling((x, y, z), pattern_ids, BinomialLabeling(4, 0.8))
+```
+
+## Sampling Fluorophore Counts Directly
+
+Use `n_fluorophores` to sample the count for a single site:
+
+```julia
+labeling = PoissonLabeling(1.5)
+n = n_fluorophores(labeling)  # Returns Int (can be 0)
+```
+
+See the [API Reference](@ref) page for complete docstrings.

--- a/docs/src/core/noise.md
+++ b/docs/src/core/noise.md
@@ -33,18 +33,18 @@ This formula captures the key insight that localization precision improves with:
 
 ## Implementing Uncertainty in SMLMSim
 
-SMLMSim applies localization uncertainty using the `noise()` function, which adds position errors based on photon counts:
+SMLMSim applies localization uncertainty using the `apply_noise()` function, which adds position errors based on photon counts:
 
 ```julia
 # Apply localization uncertainty to model with kinetic blinking
-smld_noisy = noise(smld_model, 0.13)  # 0.13μm = 130nm PSF width
+smld_noisy = apply_noise(smld_model, 0.13)  # 0.13μm = 130nm PSF width
 ```
 
 For 3D simulations, you specify the PSF width in each dimension:
 
 ```julia
 # Apply 3D localization uncertainty
-smld_noisy_3d = noise(smld_model_3d, [0.13, 0.13, 0.39])  # [σx, σy, σz] in μm
+smld_noisy_3d = apply_noise(smld_model_3d, [0.13, 0.13, 0.39])  # [σx, σy, σz] in μm
 ```
 
 Note that the axial (z) uncertainty is typically 2-3× larger than the lateral (x,y) uncertainty.
@@ -57,15 +57,15 @@ The `StaticSMLMConfig` includes a parameter `σ_psf` that controls the PSF width
 # Create simulation parameters with specific PSF width
 params = StaticSMLMConfig(
     σ_psf=0.15,  # 150nm PSF width
-    ρ=1.0,       # 1 pattern per μm²
+    density=1.0, # 1 pattern per μm²
     nframes=1000
 )
 
 # Run simulation
-smld_true, smld_model, smld_noisy = simulate(params)
+smld_noisy, info = simulate(params)
 ```
 
-The third returned object (`smld_noisy`) contains emitters with:
+The first returned object (`smld_noisy`) contains emitters with:
 - Position noise added according to the PSF width and photon counts
 - Uncertainty fields (`σ_x`, `σ_y`, and for 3D `σ_z`) populated with the theoretical uncertainty values
 
@@ -101,10 +101,10 @@ The PSF width is the most important parameter affecting localization uncertainty
 
 ```julia
 # Simulation with wider PSF (150nm)
-smld_true, smld_model, smld_wide_psf = simulate(σ_psf=0.15)
+smld_wide_psf, info_wide = simulate(σ_psf=0.15)
 
 # Simulation with narrower PSF (100nm)
-smld_true, smld_model, smld_narrow_psf = simulate(σ_psf=0.10)
+smld_narrow_psf, info_narrow = simulate(σ_psf=0.10)
 ```
 
 Realistic PSF widths depend on:
@@ -131,9 +131,9 @@ bright_fluor = GenericFluor(5e4, [-5.0 5.0; 1.0 -1.0])
 dim_fluor = GenericFluor(5e3, [-5.0 5.0; 1.0 -1.0])
 
 # Bright emitters with lower uncertainty
-smld_true, smld_model, smld_bright = simulate(molecule=bright_fluor)
+smld_bright, info_bright = simulate(molecule=bright_fluor)
 
 # Dim emitters with higher uncertainty
-smld_true, smld_model, smld_dim = simulate(molecule=dim_fluor)
+smld_dim, info_dim = simulate(molecule=dim_fluor)
 ```
 

--- a/docs/src/core/patterns.md
+++ b/docs/src/core/patterns.md
@@ -79,12 +79,12 @@ custom_line3d = Line3D(
 
 Individual patterns define the arrangement of a single group of molecules. To create realistic samples, you'll typically want to distribute many instances of a pattern throughout the field of view.
 
-The `simulate()` function handles this automatically with the density parameter `ρ`:
+The `simulate()` function handles this automatically with the `density` parameter:
 
 ```julia
 # Simulate with 2 patterns per square micron
-smld_true, smld_model, smld_noisy = simulate(
-    ρ=2.0,
+smld_noisy, info = simulate(
+    density=2.0,
     pattern=Nmer2D(n=6, d=0.2)
 )
 ```
@@ -173,6 +173,6 @@ end
 
 # Use your custom pattern
 grid = Grid2D(nx=4, ny=3, dx=0.1, dy=0.15)
-smld_true, smld_model, smld_noisy = simulate(pattern=grid)
+smld_noisy, info = simulate(pattern=grid)
 ```
 

--- a/docs/src/core/photophysics.md
+++ b/docs/src/core/photophysics.md
@@ -93,7 +93,7 @@ To simulate the fluorescence signal over time, SMLMSim integrates photon emissio
 
 ```julia
 # Generate intensity trace for 1000 frames at 50 fps
-fluor = GenericFluor(γ=10000.0, q=[-5 5; 10 -10])
+fluor = GenericFluor(10000.0, [-5 5; 10 -10])
 photons = intensity_trace(fluor, 1000, 50.0)
 ```
 
@@ -112,8 +112,8 @@ The simplest model contains just ON and OFF states:
 # Two-state model (ON ⟷ OFF)
 # kon = 5 s⁻¹, koff = 10 s⁻¹
 fluor = GenericFluor(
-    γ=1e4,                # 10,000 photons/s
-    q=[-10 10; 5 -5]      # [ON→OFF; OFF→ON] rates in s⁻¹
+    1e4,                  # 10,000 photons/s
+    [-10 10; 5 -5]        # [ON→OFF; OFF→ON] rates in s⁻¹
 )
 ```
 
@@ -127,8 +127,8 @@ For more realistic behavior including photobleaching:
 # Three-state model (ON ⟷ OFF → BLEACHED)
 # State 1: ON, State 2: OFF, State 3: BLEACHED
 fluor = GenericFluor(
-    γ=1e4,
-    q=[-10.1 10 0.1; 5 -5 0; 0 0 0]  # Note: state 3 is absorbing (no outgoing transitions)
+    1e4,
+    [-10.1 10 0.1; 5 -5 0; 0 0 0]    # Note: state 3 is absorbing (no outgoing transitions)
 )
 ```
 
@@ -141,9 +141,9 @@ The `simulate()` function integrates these photophysical models automatically:
 ```julia
 # Simulation with custom fluorophore
 camera = IdealCamera(128, 128, 0.1)
-fluor = GenericFluor(γ=2e4, q=[-20 20; 5 -5])
+fluor = GenericFluor(2e4, [-20 20; 5 -5])
 
-smld_true, smld_model, smld_noisy = simulate(
+smld_noisy, info = simulate(
     molecule=fluor,
     framerate=50.0,     # frames per second
     nframes=2000,       # total frames

--- a/docs/src/diffusion/examples.md
+++ b/docs/src/diffusion/examples.md
@@ -40,7 +40,7 @@ params = DiffusionSMLMConfig(
 )
 
 # Run simulation
-smld = simulate(params; photons=1000.0)
+smld, info = simulate(params; photons=1000.0)
 
 # Extract coordinates based on monomer/dimer state for a specific frame
 function extract_frame_by_state(smld, frame_num)
@@ -126,7 +126,7 @@ params = DiffusionSMLMConfig(
 )
 
 # Run simulation
-smld = simulate(params)
+smld, info = simulate(params)
 
 # Setup camera and PSF
 pixelsize = 0.1  # 100nm pixels
@@ -140,7 +140,7 @@ psf = MicroscopePSFs.GaussianPSF(0.15)  # 150nm PSF width
 # For diffusion simulations, the camera integration time (exposure) has already been
 # modeled in the simulation process, so each frame already includes the positions
 # from all emitters that appeared during the exposure window
-images = gen_images(smld, psf;
+images, img_info = gen_images(smld, psf;
     bg=5.0,               # background photons per pixel
     poisson_noise=true     # add photon counting noise
 )
@@ -193,8 +193,8 @@ params_unstable = DiffusionSMLMConfig(
 )
 
 # Run simulations
-smld_stable = simulate(params_stable)
-smld_unstable = simulate(params_unstable)
+smld_stable, info_stable = simulate(params_stable)
+smld_unstable, info_unstable = simulate(params_unstable)
 
 # Analyze dimer formation
 frames_stable, frac_stable = analyze_dimer_fraction(smld_stable)
@@ -249,7 +249,7 @@ params = DiffusionSMLMConfig(
 )
 
 # Run simulation
-smld = simulate(params)
+smld, info = simulate(params)
 
 # Set up camera and PSF
 pixelsize = 0.1  # 100nm pixels
@@ -260,7 +260,7 @@ camera = IdealCamera(1:pixels, 1:pixels, pixelsize)
 psf = MicroscopePSFs.GaussianPSF(0.15)  # 150nm PSF width
 
 # Generate images for all molecules
-images_all = gen_images(smld, psf;
+images_all, img_info_all = gen_images(smld, psf;
     bg=5.0,
     poisson_noise=true
 )
@@ -269,7 +269,7 @@ images_all = gen_images(smld, psf;
 dimer_smld = get_dimers(smld)
 
 # Generate images showing only dimers
-images_dimers = gen_images(dimer_smld, psf;
+images_dimers, img_info_dimers = gen_images(dimer_smld, psf;
     bg=5.0,
     poisson_noise=true
 )
@@ -354,7 +354,7 @@ particle2 = DiffusingEmitter2D{Float64}(
 )
 
 # Run simulation with custom starting positions
-smld = simulate(params; starting_conditions=[particle1, particle2])
+smld, info = simulate(params; starting_conditions=[particle1, particle2])
 
 track_smlds = get_tracks(smld)
 

--- a/docs/src/diffusion/overview.md
+++ b/docs/src/diffusion/overview.md
@@ -62,10 +62,10 @@ params = DiffusionSMLMConfig(
 )
 
 # Run the simulation
-smld = simulate(params)
+smld, info = simulate(params)
 ```
 
-The `smld` output is a `BasicSMLD` structure containing all emitters across all time points, with each emitter having frame information corresponding to the camera settings.
+The `smld` output is a `BasicSMLD` structure containing all emitters across all time points, with each emitter having frame information corresponding to the camera settings. The `info` struct contains additional simulation metadata such as `info.elapsed_s`.
 
 ## Simulation Parameters
 
@@ -110,7 +110,7 @@ using MicroscopePSFs
 psf = MicroscopePSFs.GaussianPSF(0.15)  # 150nm PSF width
 
 # Generate images
-image_stack = gen_images(smld, psf;
+image_stack, img_info = gen_images(smld, psf;
     photons=1000.0,
     bg=5.0,
     poisson_noise=true

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -60,7 +60,7 @@ using SMLMSim
 camera = IdealCamera(128, 128, 0.1)
 
 # Run a basic static simulation
-smld_true, smld_model, smld_noisy = simulate(
+smld_noisy, info = simulate(
     density=1.0,                # 1 pattern per μm²
     σ_psf=0.13,           # 130nm PSF width
     pattern=Nmer2D(n=8, d=0.1),  # 8-molecule circular pattern (100nm diameter)
@@ -83,7 +83,7 @@ params = DiffusionSMLMConfig(
 )
 
 # Run diffusion simulation
-smld_diffusion = simulate(params)
+smld_diffusion, info = simulate(params)
 ```
 
 ## Package Structure

--- a/docs/src/static/examples.md
+++ b/docs/src/static/examples.md
@@ -24,7 +24,7 @@ params = StaticSMLMConfig(
 )
 
 # Run simulation with specified pattern and camera
-smld_true, smld_model, smld_noisy = simulate(
+smld_noisy, info = simulate(
     params;
     pattern=Nmer2D(n=6, d=0.2),  # hexamer with 200nm diameter
     camera=camera
@@ -81,7 +81,7 @@ params = StaticSMLMConfig(
 )
 
 # Run 3D simulation
-smld_true, smld_model, smld_noisy = simulate(
+smld_noisy, info = simulate(
     params;
     pattern=Nmer3D(n=8, d=0.2),  # 3D pattern with 200nm diameter
     camera=camera
@@ -137,7 +137,7 @@ params = StaticSMLMConfig(
 )
 
 # Run simulation
-smld_true, smld_model, smld_noisy = simulate(
+smld_noisy, info = simulate(
     params;
     pattern=Nmer2D(n=6, d=0.2),  # hexamer with 200nm diameter
     camera=camera
@@ -146,11 +146,11 @@ smld_true, smld_model, smld_noisy = simulate(
 # Create a PSF model (Gaussian with 150nm width)
 psf = MicroscopePSFs.GaussianPSF(0.15)  # 150nm PSF width
 
-# Note: We use smld_model (not smld_noisy) to avoid double-counting uncertainty
+# Note: We use info.smld_model (not smld_noisy) to avoid double-counting uncertainty
 # smld_noisy already contains localization errors, and rendering camera images
 # naturally introduces noise, so using smld_noisy would apply noise twice
 # Generate image stack from emitter data with Poisson noise
-images = gen_images(smld_model, psf;
+images, img_info = gen_images(info.smld_model, psf;
     bg=5.0,            # background photons per pixel
     poisson_noise=true  # add realistic shot noise
 )
@@ -175,7 +175,7 @@ ax2 = Axis(fig[1, 2],
 )
 
 # Extract emitters in frame 20
-frame20_emitters = filter(e -> e.frame == 20, smld_model.emitters)
+frame20_emitters = filter(e -> e.frame == 20, info.smld_model.emitters)
 x = [e.x for e in frame20_emitters]
 y = [e.y for e in frame20_emitters]
 photons = [e.photons for e in frame20_emitters]
@@ -253,7 +253,7 @@ params = StaticSMLMConfig(
 )
 
 # Run simulation with custom pattern
-smld_true, smld_model, smld_noisy = simulate(
+smld_noisy, info = simulate(
     params;
     pattern=grid,
     camera=camera
@@ -278,8 +278,8 @@ ax2 = Axis(fig[1, 2],
 )
 
 # Extract coordinates
-x_true = [e.x for e in smld_true.emitters]
-y_true = [e.y for e in smld_true.emitters]
+x_true = [e.x for e in info.smld_true.emitters]
+y_true = [e.y for e in info.smld_true.emitters]
 
 x_noisy = [e.x for e in smld_noisy.emitters]
 y_noisy = [e.y for e in smld_noisy.emitters]

--- a/docs/src/static/overview.md
+++ b/docs/src/static/overview.md
@@ -55,7 +55,7 @@ The high-level `simulate()` function provides a simple interface for static simu
 camera = IdealCamera(128, 128, 0.1)  # 128×128 pixels, 100nm pixels
 
 # Run simulation with parameters
-smld_true, smld_model, smld_noisy = simulate(
+smld_noisy, info = simulate(
     params,
     pattern=Nmer2D(n=6, d=0.2),  # hexamer with 200nm diameter
     molecule=GenericFluor(1e4, [-10.0 10.0; 0.5 -0.5]),  # fluorophore model
@@ -66,7 +66,7 @@ smld_true, smld_model, smld_noisy = simulate(
 Alternatively, you can use keyword arguments directly:
 
 ```julia
-smld_true, smld_model, smld_noisy = simulate(
+smld_noisy, info = simulate(
     density=1.0,                # patterns per μm²
     σ_psf=0.13,           # PSF width in μm
     nframes=1000,         # frames
@@ -79,22 +79,17 @@ smld_true, smld_model, smld_noisy = simulate(
 
 ## Understanding Simulation Results
 
-The `simulate()` function returns three `SMLD` objects:
+The `simulate()` function returns a tuple `(smld_noisy, info::SimInfo)`:
 
-1. **`smld_true`**: Ground truth emitter positions
-   - Contains the exact coordinates of all emitters
-   - Single frame (no temporal information)
-   - No blinking or noise applied
-
-2. **`smld_model`**: Positions with blinking kinetics
-   - Subset of true positions appearing in different frames
-   - Realistic blinking behavior based on kinetic model
-   - No position uncertainty (exact coordinates)
-
-3. **`smld_noisy`**: Positions with blinking and localization uncertainty
-   - Same temporal distribution as `smld_model`
+1. **`smld_noisy`**: Positions with blinking and localization uncertainty
    - Position noise based on photon statistics
+   - Realistic blinking behavior based on kinetic model
    - Most comparable to real experimental data
+
+2. **`info`**: A `SimInfo` struct containing additional simulation data:
+   - **`info.smld_true`**: Ground truth emitter positions (exact coordinates, no blinking or noise)
+   - **`info.smld_model`**: Positions with blinking kinetics (no position uncertainty)
+   - **`info.elapsed_s`**: Simulation elapsed time in seconds
 
 Each SMLD object contains emitters with properties like position, frame number, photon count, and uncertainties.
 
@@ -127,12 +122,12 @@ The dimensionality of the simulation is controlled by both the `ndims` parameter
 # 2D simulation
 params = StaticSMLMConfig(ndims=2)
 pattern2d = Nmer2D(n=6, d=0.2)
-smld_true_2d, smld_model_2d, smld_noisy_2d = simulate(params, pattern=pattern2d)
+smld_noisy_2d, info_2d = simulate(params, pattern=pattern2d)
 
 # 3D simulation
 params = StaticSMLMConfig(ndims=3, zrange=[-2.0, 2.0])
 pattern3d = Nmer3D(n=6, d=0.2)
-smld_true_3d, smld_model_3d, smld_noisy_3d = simulate(params, pattern=pattern3d)
+smld_noisy_3d, info_3d = simulate(params, pattern=pattern3d)
 ```
 
 For 3D simulations, the localization uncertainty is automatically scaled in the axial dimension to reflect the typically lower z-resolution in SMLM experiments.

--- a/src/SMLMSim.jl
+++ b/src/SMLMSim.jl
@@ -29,15 +29,16 @@ using SMLMSim
 
 # Example: Static simulation
 params_static = StaticSMLMConfig(density=1.0, σ_psf=0.13)
-_, _, smld_noisy = simulate(params_static)
+smld_noisy, info = simulate(params_static)
+# Access intermediate results: info.smld_true, info.smld_model
 
 # Example: Diffusion simulation
 params_diff = DiffusionSMLMConfig(density=0.5, diff_monomer=0.1)
-smld_diff = simulate(params_diff)
+smld, info = simulate(params_diff)
 
 # Example: Generate images
 psf = GaussianPSF(0.15)
-images = gen_images(smld_noisy, psf)
+images, img_info = gen_images(smld_noisy, psf)
 ```
 """
 module SMLMSim
@@ -98,9 +99,8 @@ export
 # Export simulation functions
 export
     # Kinetic simulation
-    intensity_trace, # Renamed from intensitytrace to match function name
-    kinetic_model,   # Renamed from kineticmodel to match function name
-    noise,
+    intensity_trace,
+    kinetic_model,
     
     # CTMC type and functions
     CTMC,


### PR DESCRIPTION
## Summary

- **Tuple return pattern**: `simulate()` now returns `(smld_noisy, info::SimInfo)` and `gen_images()` returns `(images, info::ImageInfo)` — intermediate results accessible via `info.smld_true`, `info.smld_model`
- **Labeling system**: New `AbstractLabeling` types (`FixedLabeling`, `PoissonLabeling`, `BinomialLabeling`) control fluorophore attachment per binding site
- **SMLMData 0.7**: Types inherit from SMLMData abstract types (`AbstractSMLMConfig`, `AbstractSMLMInfo`); compat narrowed to 0.7 only
- **Config rename**: `StaticSMLMParams` → `StaticSMLMConfig`, `DiffusionSMLMParams` → `DiffusionSMLMConfig`
- **Other**: `elapsed_ns` → `elapsed_s`, `pattern_ids` tracking, `burn_in` parameter, `σ_xy` covariance support

### Breaking Changes
- `simulate()` return type changed from 3-tuple/single to `(output, info)` tuple
- Config struct names changed (`*Params` → `*Config`)
- Requires SMLMData 0.7 (drops 0.4-0.6 compat)
- `elapsed_ns` field renamed to `elapsed_s` (now in seconds)

## Test plan
- [x] All 275 tests pass
- [x] README, docs/, api_overview.md verified against source code
- [ ] Docs build locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)