### PR TITLE
ci: bump GitHub Actions to current majors for Node.js 24 deadline

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
+          files: lcov.info
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,11 +18,11 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1.9.0
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:
@@ -32,10 +32,10 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@v1.4.0
-      - uses: julia-actions/julia-runtest@v1.9.0
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v5
         with:
           file: lcov.info
   docs:
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1.9.0
+      - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
       - run: |


### PR DESCRIPTION
## Summary

GitHub Actions is forcing all workflows to Node.js 24 on **2026-06-02** and removing Node.js 20 entirely on **2026-09-16**. Several pinned actions in `CI.yml` ran on Node.js 16/20 and would break.

## Changes

Bumped action versions in `.github/workflows/CI.yml` only:

- `julia-actions/setup-julia`: `v1.9.0` → `v2`
- `actions/cache`: `v3` → `v4`
- `julia-actions/julia-buildpkg`: `v1.4.0` → `v1`
- `julia-actions/julia-runtest`: `v1.9.0` → `v1`
- `codecov/codecov-action`: `v3` → `v5`

`actions/checkout@v4` and `julia-actions/julia-processcoverage@v1` were already current. `CompatHelper.yml` (no third-party actions) and `TagBot.yml` (`JuliaRegistries/TagBot@v1` is current) needed no changes.

## Test plan

- [ ] CI passes on this PR (validates the new action versions work end-to-end)
- [ ] Codecov upload still functions with v5

🤖 Generated with [Claude Code](https://claude.com/claude-code)