### PR TITLE
Add Nanoruler2D/3D pattern (GATTAquant DNA-PAINT calibration rulers)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SMLMSim"
 uuid = "5a0a87e4-02d4-41f5-bf26-b8c94c784a04"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["klidke@unm.edu"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Define spatial arrangements (see `Pattern` types like `Nmer2D`, `Line3D`, `unifo
 # Examples:
 nmer = Nmer2D(n=8, d=0.1)  # 8 molecules in a 100nm diameter circle
 line = Line3D(λ=5.0, endpoints=[(-1.0, 0.0, -0.5), (1.0, 0.0, 0.5)]) # 5 mols/μm
+ruler = Nanoruler2D(spacing=0.02)  # GATTAquant-style 3-mark ruler, 20nm spacing
 ```
 
 ### Labeling

--- a/api_overview.md
+++ b/api_overview.md
@@ -33,9 +33,11 @@ All simulations use consistent physical units:
   - `Pattern2D`: Base type for 2D patterns
     - `Nmer2D`: N molecules arranged in a circle
     - `Line2D`: Molecules arranged along a line
+    - `Nanoruler2D`: N collinear, uniformly-spaced marks (DNA-PAINT nanoruler)
   - `Pattern3D`: Base type for 3D patterns
     - `Nmer3D`: N molecules arranged in a circle in 3D
     - `Line3D`: Molecules arranged along a 3D line
+    - `Nanoruler3D`: N collinear, uniformly-spaced marks in 3D (DNA-PAINT nanoruler)
 
 - `AbstractLabeling`: Base type for labeling strategies
   - `FixedLabeling`: Deterministic number of fluorophores per site
@@ -117,6 +119,20 @@ mutable struct Line2D <: Pattern2D
     y::Vector{Float64}    # Y positions of molecules in microns
     λ::Float64            # Linear molecule density (molecules per micron)
     endpoints::Vector{Tuple{Float64,Float64}}  # Vector of endpoint coordinates
+end
+```
+
+#### Nanoruler2D
+
+`n` collinear marks with uniform spacing, modeling DNA-PAINT calibration
+nanorulers (e.g. GATTAquant). `Nanoruler3D` is the 3D analog (adds a `z` field).
+
+```julia
+mutable struct Nanoruler2D <: Pattern2D
+    n::Int               # Number of marks in the pattern (default 3)
+    spacing::Float64     # Distance between adjacent marks in microns
+    x::Vector{Float64}   # X positions of marks in microns
+    y::Vector{Float64}   # Y positions of marks in microns
 end
 ```
 
@@ -263,6 +279,10 @@ line = Line2D(λ=5.0, endpoints=[(-2.0, 0.0), (2.0, 0.0)])  # 5 molecules/μm
 
 # Create a 3D line pattern
 line3d = Line3D(λ=8.0, endpoints=[(-1.0, 0.0, -0.5), (1.0, 0.0, 0.5)])
+
+# Create a DNA-PAINT nanoruler: 3 collinear marks, 20nm spacing (GATTAquant-style)
+ruler = Nanoruler2D(spacing=0.02)
+ruler3d = Nanoruler3D(n=3, spacing=0.04)
 ```
 
 ### Creating Fluorophore Models

--- a/dev/test_nanoruler.jl
+++ b/dev/test_nanoruler.jl
@@ -1,0 +1,137 @@
+# test_nanoruler.jl - Simulate GATTAquant-style Nanoruler structures and verify
+# the geometry round-trips through the simulation pipeline.
+#
+# SCOPE: SMLMSim is a *simulation* package. This script exercises the simulation
+# pipeline (pattern -> random placement/rotation -> blinking -> localization
+# noise) and quantitatively verifies the ground-truth geometry of the new
+# Nanoruler patterns. The full *analysis* round-trip (camera images ->
+# localization fitting -> blink grouping -> clustering -> recovered spacing)
+# belongs in SMLMAnalysis, not here -- SMLMSim has no fitting code.
+#
+# API: v0.7.0 -- StaticSMLMConfig + 2-tuple `simulate` return (smld, info).
+# Runs headless by default; set SHOW_PLOTS = true for interactive GLMakie figures.
+
+using Pkg
+Pkg.activate(@__DIR__)
+using Revise
+
+using SMLMSim
+using Statistics
+using LinearAlgebra
+
+const SHOW_PLOTS = false   # set true for interactive GLMakie figures
+
+# --- helpers ---------------------------------------------------------------
+
+"Group emitter indices by pattern id (one group per ruler instance)."
+function group_by_id(emitters)
+    groups = Dict{Int,Vector{Int}}()
+    for (i, e) in enumerate(emitters)
+        push!(get!(groups, e.id, Int[]), i)
+    end
+    return groups
+end
+
+"""
+    recovered_gaps(pts) -> Vector
+
+Recover the adjacent-mark spacings of (near-)collinear points by projecting
+them onto their principal axis (PCA) and taking sorted gaps. `pts` is an
+`(n, d)` matrix. Rotation-invariant; exact for noise-free collinear marks.
+"""
+function recovered_gaps(pts::AbstractMatrix)
+    μ = mean(pts, dims=1)
+    centered = pts .- μ
+    C = Symmetric(centered' * centered)
+    axis = eigvecs(C)[:, end]              # principal direction (largest eigenvalue)
+    proj = sort(vec(centered * axis))
+    return diff(proj)
+end
+
+# --- simulation ------------------------------------------------------------
+
+spacing = 0.02                              # 20 nm between adjacent marks
+camera  = IdealCamera(1:128, 1:128, 0.1)    # 12.8 μm field, 100 nm pixels
+ruler   = Nanoruler2D(spacing=spacing)      # default: 3-mark GATTAquant ruler
+
+# High photon budget -> localization precision (σ_psf / sqrt(photons)) well below
+# the 20 nm spacing, so the sub-diffraction ruler is resolvable in the noisy data.
+fluor = GenericFluor(photons=1e5, k_off=50.0, k_on=1e-2)
+
+params = StaticSMLMConfig(
+    density    = 1.0,    # rulers per μm^2
+    σ_psf      = 0.13,   # 130 nm PSF; localization precision = σ_psf / sqrt(photons)
+    minphotons = 50,
+    ndatasets  = 1,
+    nframes    = 1000,
+    framerate  = 50.0,
+    ndims      = 2,
+)
+
+println("Simulating Nanoruler2D (n=$(ruler.n), spacing=$(spacing*1e3) nm)...")
+smld, info = simulate(params; pattern=ruler, molecule=fluor, camera=camera)
+
+println("\nSimulation summary")
+println("  rulers placed      : ", info.n_patterns)
+println("  ground-truth marks : ", info.n_emitters,
+        "  (expected ", info.n_patterns * ruler.n, ")")
+println("  noisy localizations: ", info.n_localizations)
+
+# --- 1. ground-truth geometry check (rigorous) -----------------------------
+
+println("\n[1] Ground-truth geometry (info.smld_true)")
+gt = info.smld_true.emitters
+groups = group_by_id(gt)
+
+all_gaps = Float64[]
+nmark_ok = true
+for (id, idxs) in groups
+    global nmark_ok &= length(idxs) == ruler.n
+    pts = reduce(vcat, ([gt[i].x gt[i].y] for i in idxs))
+    append!(all_gaps, recovered_gaps(pts))
+end
+
+println("  rulers checked          : ", length(groups))
+println("  all have n=$(ruler.n) marks    : ", nmark_ok)
+println("  recovered spacing       : ", round(mean(all_gaps)*1e3, digits=4), " ± ",
+        round(std(all_gaps)*1e3, digits=4), " nm  (true = ", spacing*1e3, " nm)")
+pass = nmark_ok && isapprox(mean(all_gaps), spacing; atol=1e-6)
+println("  RESULT: ", pass ? "PASS" : "FAIL")
+
+# --- 2. localization precision (is the structure resolvable after imaging?) -
+
+println("\n[2] Localization precision in noisy data")
+photons = [e.photons for e in smld.emitters]
+σ_loc = params.σ_psf ./ sqrt.(photons)      # SMLM precision = σ_psf / sqrt(N)
+println("  median photons/loc : ", round(median(photons), digits=0))
+println("  median σ_loc       : ", round(median(σ_loc)*1e3, digits=2), " nm")
+println("  spacing / σ_loc    : ", round(spacing / median(σ_loc), digits=1),
+        "   (> ~2 means the 20 nm marks are resolvable)")
+println("\nNote: recovering spacing from the *noisy* localizations (grouping blinks,")
+println("      fitting, clustering) is an analysis task -> SMLMAnalysis.")
+
+# --- 3. optional visualization ---------------------------------------------
+
+if SHOW_PLOTS
+    using GLMakie
+    noisy_groups = group_by_id(smld.emitters)
+    # pick the ruler with the most noisy localizations for a clear close-up
+    id_best = argmax(id -> length(noisy_groups[id]), keys(noisy_groups))
+    gi, ni = groups[id_best], noisy_groups[id_best]
+
+    fig = Figure(size=(950, 460))
+    ax1 = Axis(fig[1, 1], title="All rulers (ground truth)",
+               xlabel="X (μm)", ylabel="Y (μm)", aspect=DataAspect())
+    scatter!(ax1, [e.x for e in gt], [e.y for e in gt],
+             color=[e.id for e in gt], colormap=:viridis, markersize=4)
+
+    ax2 = Axis(fig[1, 2], title="One ruler: truth (×) vs noisy (·)",
+               xlabel="X (μm)", ylabel="Y (μm)", aspect=DataAspect())
+    scatter!(ax2, [smld.emitters[i].x for i in ni], [smld.emitters[i].y for i in ni],
+             color=(:red, 0.3), markersize=5, label="noisy")
+    scatter!(ax2, [gt[i].x for i in gi], [gt[i].y for i in gi],
+             color=:black, marker=:xcross, markersize=16, label="true marks")
+    axislegend(ax2)
+    display(fig)
+    println("\nClose the window to exit.")
+end

--- a/docs/src/core/patterns.md
+++ b/docs/src/core/patterns.md
@@ -46,6 +46,23 @@ custom_line = Line2D(λ=5.0, endpoints=[(-2.0, 0.0), (2.0, 0.0)])
 
 The density parameter λ (lambda) specifies the average number of molecules per micron along the line. The actual number of molecules is drawn from a Poisson distribution.
 
+### Nanoruler2D
+
+The `Nanoruler2D` pattern creates `n` marks arranged collinearly with uniform `spacing`, modeling DNA-PAINT calibration nanorulers (e.g. GATTAquant). Unlike `Line2D`, the marks are deterministic and evenly spaced. The marks lie on the x-axis centered on the origin; `uniform2D` then applies random placement and rotation.
+
+```julia
+# Default 3-mark nanoruler with 40 nm spacing
+ruler = Nanoruler2D()
+
+# GATTAquant-style 3-mark ruler with 20 nm spacing (marks at -20, 0, +20 nm)
+ruler = Nanoruler2D(spacing=0.02)
+
+# 5-mark ruler with 50 nm spacing
+ruler = Nanoruler2D(n=5, spacing=0.05)
+```
+
+`spacing` is the distance between adjacent marks in microns, so the total ruler length is `(n - 1) * spacing`.
+
 ## 3D Patterns
 
 ### Nmer3D
@@ -73,6 +90,21 @@ custom_line3d = Line3D(
     λ=5.0,  # molecules per micron
     endpoints=[(-1.0, 0.0, -0.5), (1.0, 0.0, 0.5)]
 )
+```
+
+### Nanoruler3D
+
+The `Nanoruler3D` pattern is the 3D equivalent of `Nanoruler2D`: `n` collinear marks with uniform `spacing` along the x-axis at z=0. `uniform3D` then applies a random 3D rotation, giving the rod-like ruler a random orientation in space.
+
+```julia
+# Default 3-mark nanoruler with 40 nm spacing
+ruler3d = Nanoruler3D()
+
+# GATTAquant-style 3-mark ruler with 20 nm spacing
+ruler3d = Nanoruler3D(spacing=0.02)
+
+# 5-mark ruler with 50 nm spacing
+ruler3d = Nanoruler3D(n=5, spacing=0.05)
 ```
 
 ## Creating Pattern Distributions

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -92,7 +92,7 @@ SMLMSim is built upon [SMLMData.jl](https://github.com/JuliaSMLM/SMLMData.jl), r
 
 The main components of the package are:
 
-- **Patterns**: Spatial arrangements of molecules (Nmer2D, Line2D, etc.)
+- **Patterns**: Spatial arrangements of molecules (Nmer2D, Line2D, Nanoruler2D, etc.)
 - **Molecules**: Photophysical models (e.g., GenericFluor)
 - **Simulation**: Kinetic models and noise generation
 - **Diffusion**: Smoluchowski dynamics for molecular interactions

--- a/src/SMLMSim.jl
+++ b/src/SMLMSim.jl
@@ -62,7 +62,7 @@ include("interface.jl")
 # Import specific functions from Core
 using .Core: CTMC, get_state, get_next, intensity_trace, kinetic_model
 using .Core: Molecule, GenericFluor, Pattern, Pattern2D, Pattern3D
-using .Core: Nmer2D, Nmer3D, Line2D, Line3D, uniform2D, uniform3D, rotate!
+using .Core: Nmer2D, Nmer3D, Line2D, Line3D, Nanoruler2D, Nanoruler3D, uniform2D, uniform3D, rotate!
 using .Core: SMLMSimParams
 using .Core: get_track, get_num_tracks, get_tracks # Track utility functions
 using .Core: AbstractLabeling, FixedLabeling, PoissonLabeling, BinomialLabeling
@@ -138,6 +138,8 @@ export
     Nmer3D,
     Line2D,
     Line3D,
+    Nanoruler2D,
+    Nanoruler3D,
 
     # Pattern generation
     uniform2D,

--- a/src/core/Core.jl
+++ b/src/core/Core.jl
@@ -71,6 +71,8 @@ export
     Nmer3D,
     Line2D,
     Line3D,
+    Nanoruler2D,
+    Nanoruler3D,
 
     # Pattern generation
     uniform2D,

--- a/src/core/patterns.jl
+++ b/src/core/patterns.jl
@@ -308,6 +308,142 @@ function Base.show(io::IO, ::MIME"text/plain", line::Line3D)
 end
 
 #==========================================================================
+Nanoruler Pattern Types
+==========================================================================#
+
+"""
+    Nanoruler2D <: Pattern2D
+
+`n` fluorophore marks arranged collinearly with uniform spacing, modeling
+DNA-PAINT calibration nanorulers (e.g. GATTAquant). Marks lie on the x-axis,
+centered on the origin; `uniform2D` then applies random placement and rotation.
+
+# Fields
+- `n::Int`: Number of marks in the pattern
+- `spacing::Float64`: Distance between adjacent marks in microns
+- `x::Vector{Float64}`: X positions of marks in microns
+- `y::Vector{Float64}`: Y positions of marks in microns
+
+# Examples
+```julia
+# Default 3-mark nanoruler with 40 nm spacing
+ruler = Nanoruler2D()
+
+# GATTAquant-style 3-mark ruler with 20 nm spacing (marks at -20, 0, +20 nm)
+ruler = Nanoruler2D(; spacing=0.02)
+
+# 5-mark ruler with 50 nm spacing
+ruler = Nanoruler2D(; n=5, spacing=0.05)
+```
+"""
+mutable struct Nanoruler2D <: Pattern2D
+    n::Int
+    spacing::Float64
+    x::Vector{Float64}
+    y::Vector{Float64}
+end
+
+function Nanoruler2D(; n::Int=3, spacing::Float64=0.04)
+    ruler = Nanoruler2D(n, spacing, zeros(n), zeros(n))
+    for nn = 1:n
+        ruler.x[nn] = (nn - (n + 1) / 2) * spacing
+        ruler.y[nn] = 0.0
+    end
+    return ruler
+end
+
+function Base.show(io::IO, ruler::Nanoruler2D)
+    print(io, "Nanoruler2D(n=$(ruler.n), spacing=$(ruler.spacing) μm)")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", ruler::Nanoruler2D)
+    println(io, "Nanoruler2D pattern:")
+    println(io, "  Number of marks (n) = $(ruler.n)")
+    println(io, "  Spacing = $(ruler.spacing) μm ($(ruler.spacing*1000) nm)")
+    println(io, "  Total length = $(round((ruler.n - 1) * ruler.spacing, digits=4)) μm")
+
+    if ruler.n <= 10  # Only show coordinates for small patterns
+        println(io, "  Coordinates (μm):")
+        for i in 1:ruler.n
+            print(io, "    [$(i)]: (")
+            print(io, @sprintf("%.3f", ruler.x[i]))
+            print(io, ", ")
+            print(io, @sprintf("%.3f", ruler.y[i]))
+            println(io, ")")
+        end
+    end
+end
+
+"""
+    Nanoruler3D <: Pattern3D
+
+3D equivalent of [`Nanoruler2D`](@ref): `n` fluorophore marks arranged collinearly
+with uniform spacing along the x-axis at z=0, centered on the origin. `uniform3D`
+then applies random 3D placement and rotation, giving the rod-like ruler a random
+orientation in space.
+
+# Fields
+- `n::Int`: Number of marks in the pattern
+- `spacing::Float64`: Distance between adjacent marks in microns
+- `x::Vector{Float64}`: X positions of marks in microns
+- `y::Vector{Float64}`: Y positions of marks in microns
+- `z::Vector{Float64}`: Z positions of marks in microns
+
+# Examples
+```julia
+# Default 3-mark nanoruler with 40 nm spacing
+ruler = Nanoruler3D()
+
+# GATTAquant-style 3-mark ruler with 20 nm spacing
+ruler = Nanoruler3D(; spacing=0.02)
+
+# 5-mark ruler with 50 nm spacing
+ruler = Nanoruler3D(; n=5, spacing=0.05)
+```
+"""
+mutable struct Nanoruler3D <: Pattern3D
+    n::Int
+    spacing::Float64
+    x::Vector{Float64}
+    y::Vector{Float64}
+    z::Vector{Float64}
+end
+
+function Nanoruler3D(; n::Int=3, spacing::Float64=0.04)
+    ruler = Nanoruler3D(n, spacing, zeros(n), zeros(n), zeros(n))
+    for nn = 1:n
+        ruler.x[nn] = (nn - (n + 1) / 2) * spacing
+        ruler.y[nn] = 0.0
+        ruler.z[nn] = 0.0
+    end
+    return ruler
+end
+
+function Base.show(io::IO, ruler::Nanoruler3D)
+    print(io, "Nanoruler3D(n=$(ruler.n), spacing=$(ruler.spacing) μm)")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", ruler::Nanoruler3D)
+    println(io, "Nanoruler3D pattern:")
+    println(io, "  Number of marks (n) = $(ruler.n)")
+    println(io, "  Spacing = $(ruler.spacing) μm ($(ruler.spacing*1000) nm)")
+    println(io, "  Total length = $(round((ruler.n - 1) * ruler.spacing, digits=4)) μm")
+
+    if ruler.n <= 10  # Only show coordinates for small patterns
+        println(io, "  Coordinates (μm):")
+        for i in 1:ruler.n
+            print(io, "    [$(i)]: (")
+            print(io, @sprintf("%.3f", ruler.x[i]))
+            print(io, ", ")
+            print(io, @sprintf("%.3f", ruler.y[i]))
+            print(io, ", ")
+            print(io, @sprintf("%.3f", ruler.z[i]))
+            println(io, ")")
+        end
+    end
+end
+
+#==========================================================================
 Pattern Generation Functions
 ==========================================================================#
 

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -275,6 +275,55 @@ end
         @test all(isapprox.(original_distances, rotated_distances, atol=1e-10))
     end
     
+    # Test Nanoruler pattern types (collinear, uniformly-spaced marks)
+    @testset "Nanoruler Patterns" begin
+        # Test Nanoruler2D with GATTAquant-style 20 nm spacing
+        ruler2d = Nanoruler2D(spacing=0.02)
+        @test ruler2d.n == 3  # default is the 3-mark ruler
+        @test ruler2d.spacing == 0.02
+        @test length(ruler2d.x) == 3
+        @test length(ruler2d.y) == 3
+
+        # Marks are collinear along x (y all zero) and centered on the origin
+        @test all(isapprox.(ruler2d.y, 0.0, atol=1e-12))
+        @test isapprox(sum(ruler2d.x), 0.0, atol=1e-12)
+
+        # Adjacent spacing equals `spacing`; marks at [-s, 0, +s]
+        @test all(isapprox.(diff(ruler2d.x), 0.02, atol=1e-12))
+        @test isapprox(ruler2d.x[1], -0.02, atol=1e-12)
+        @test isapprox(ruler2d.x[end], 0.02, atol=1e-12)
+
+        # General n is supported
+        ruler2d_5 = Nanoruler2D(n=5, spacing=0.05)
+        @test ruler2d_5.n == 5
+        @test length(ruler2d_5.x) == 5
+        @test all(isapprox.(diff(ruler2d_5.x), 0.05, atol=1e-12))
+
+        # Rotation preserves distance from the (origin-centered) ruler center
+        rotated = Nanoruler2D(n=3, spacing=0.02)
+        original_x = copy(rotated.x)
+        SMLMSim.rotate!(rotated, π/3)
+        @test !all(isapprox.(rotated.x, original_x, atol=1e-10))  # coords changed
+        @test all(isapprox.(
+            sqrt.(rotated.x.^2 .+ rotated.y.^2),
+            abs.(original_x),
+            atol=1e-10))
+
+        # Test Nanoruler3D (marks on x-axis, z=0 before rotation)
+        ruler3d = Nanoruler3D(n=3, spacing=0.04)
+        @test ruler3d.n == 3
+        @test length(ruler3d.z) == 3
+        @test all(isapprox.(ruler3d.y, 0.0, atol=1e-12))
+        @test all(isapprox.(ruler3d.z, 0.0, atol=1e-12))
+        @test all(isapprox.(diff(ruler3d.x), 0.04, atol=1e-12))
+
+        # Distributing rulers yields a multiple of n marks
+        x, y = SMLMSim.uniform2D(0.5, Nanoruler2D(spacing=0.02), 10.0, 10.0)
+        @test length(x) % 3 == 0
+        x3, y3, z3 = SMLMSim.uniform3D(0.5, Nanoruler3D(spacing=0.04), 10.0, 10.0, zrange=[-1.0, 1.0])
+        @test length(x3) % 3 == 0
+    end
+
     # Test pattern distribution functions
     @testset "Pattern Distribution" begin
         # Test uniform2D


### PR DESCRIPTION
## Summary
Adds `Nanoruler2D` / `Nanoruler3D` pattern types modeling GATTAquant-style DNA-PAINT calibration nanorulers: `n` collinear, uniformly-spaced marks (default `n=3`) centered on the origin, with adjustable `spacing` between adjacent marks (e.g. `spacing=0.02` → 20 nm marks at −20, 0, +20 nm).

Purely additive — `uniform2D`/`uniform3D`, `rotate!`, `apply_labeling`, and `simulate` are all pattern-agnostic, so no existing code changed.

## Changes
- `src/core/patterns.jl`: `Nanoruler2D`/`Nanoruler3D` structs, keyword constructors (`x_i = (i-(n+1)/2)·spacing`), `Base.show`
- `src/core/Core.jl`, `src/SMLMSim.jl`: exports
- `test/test_core.jl`: `Nanoruler Patterns` testset (spacing, collinearity, centering, general `n`, rotation invariance, distribution)
- `docs/src/core/patterns.md`, `README.md`: docs + example
- `dev/test_nanoruler.jl`: simulation-pipeline verification script

## Testing
Full suite passes (296 tests incl. the new testset). Verified through `simulate()`: each ruler yields exactly `n` marks and recovered spacing matches ground truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
