### PR TITLE
Migrate dev/ demo scripts to v0.7.0 API

### DIFF
--- a/dev/scmos_demo.jl
+++ b/dev/scmos_demo.jl
@@ -15,6 +15,7 @@ Parameters:
 
 using SMLMSim
 using SMLMData
+using Statistics
 using Printf
 
 println("=" ^ 80)
@@ -110,7 +111,7 @@ println("  Gain range: $(minimum(gain_map)) - $(maximum(gain_map))")
 
 # Set up diffusion simulation parameters
 println("\nRunning diffusion simulation...")
-params = DiffusionSMLMParams(
+params = DiffusionSMLMConfig(
     density = density,
     box_size = box_size,
     dt = 0.001,  # 1 ms timesteps for simulation
@@ -120,8 +121,8 @@ params = DiffusionSMLMParams(
     diff_monomer = D
 )
 
-# Run simulation
-smld = simulate(params; camera=camera_scmos, photons=photons)
+# Run simulation (returns (smld, info))
+smld, _ = simulate(params; camera=camera_scmos, photons=photons)
 
 println("  Generated $(length(smld.emitters)) localizations")
 println("  Frames: $(smld.n_frames)")
@@ -131,14 +132,14 @@ println("\nGenerating images with sCMOS camera noise...")
 using MicroscopePSFs
 psf = GaussianPSF(0.13)  # 130 nm PSF width
 
-images_scmos = gen_images(smld, psf, camera_noise=true, bg=10.0)
+images_scmos, _ = gen_images(smld, psf, camera_noise=true, bg=10.0)
 println("  Image stack size: $(size(images_scmos))")
 
 # Also generate ideal images for comparison
 println("\nGenerating ideal comparison images...")
 camera_ideal = IdealCamera(n_pixels, n_pixels, pixel_size)
 smld_ideal = BasicSMLD(smld.emitters, camera_ideal, smld.n_frames, smld.n_datasets)
-images_ideal = gen_images(smld_ideal, psf, poisson_noise=true, bg=10.0)
+images_ideal, _ = gen_images(smld_ideal, psf, poisson_noise=true, bg=10.0)
 
 # Calculate statistics
 println("\nImage Statistics:")

--- a/dev/scmos_quick_demo.jl
+++ b/dev/scmos_quick_demo.jl
@@ -60,7 +60,7 @@ emitters = Emitter2DFit{Float64}[]
 # Add grid of emitters
 for x in range(1.0, stop=box_size-1.0, length=8)
     for y in range(1.0, stop=box_size-1.0, length=8)
-        push!(emitters, Emitter2DFit(x, y, 500.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1, 1, 1, 1))
+        push!(emitters, Emitter2DFit{Float64}(x, y, 500.0, 0.0, 0.0, 0.0, 0.0, 0.0; σ_xy=0.0, frame=1, dataset=1, track_id=1, id=1))
     end
 end
 println("  Created $(length(emitters)) emitters in grid pattern")
@@ -73,16 +73,16 @@ println("\nGenerating images...")
 psf = GaussianPSF(0.13)
 
 println("  1. Clean image (no noise)...")
-img_clean = gen_images(smld_scmos, psf, bg=10.0)
+img_clean, _ = gen_images(smld_scmos, psf, bg=10.0)
 
 println("  2. sCMOS camera noise...")
-img_scmos = gen_images(smld_scmos, psf, camera_noise=true, bg=10.0)
+img_scmos, _ = gen_images(smld_scmos, psf, camera_noise=true, bg=10.0)
 
 # For comparison, make ideal camera version
 println("  3. Ideal camera (Poisson only) for comparison...")
 camera_ideal = IdealCamera(n_pixels, n_pixels, pixel_size)
 smld_ideal = BasicSMLD(emitters, camera_ideal, 1, 1)
-img_ideal = gen_images(smld_ideal, psf, poisson_noise=true, bg=10.0)
+img_ideal, _ = gen_images(smld_ideal, psf, poisson_noise=true, bg=10.0)
 
 # Statistics
 println("\nImage Statistics:")

--- a/dev/scmos_video.jl
+++ b/dev/scmos_video.jl
@@ -78,7 +78,7 @@ println("  Offset: $(round(minimum(offset_map), digits=1)) - $(round(maximum(off
 
 # Run diffusion simulation
 println("\nRunning diffusion simulation...")
-params = DiffusionSMLMParams(
+params = DiffusionSMLMConfig(
     density = density,
     box_size = box_size,
     dt = 0.001,
@@ -88,7 +88,7 @@ params = DiffusionSMLMParams(
     diff_monomer = D
 )
 
-smld = simulate(params; camera=camera_scmos, photons=photons)
+smld, _ = simulate(params; camera=camera_scmos, photons=photons)
 println("  Generated $(length(smld.emitters)) localizations")
 
 # Generate images
@@ -96,12 +96,12 @@ println("\nGenerating images...")
 psf = GaussianPSF(0.13)
 
 println("  sCMOS images (with camera_noise=true)...")
-images_scmos = gen_images(smld, psf, camera_noise=true, bg=5.0)
+images_scmos, _ = gen_images(smld, psf, camera_noise=true, bg=5.0)
 
 println("  Ideal images (for comparison)...")
 camera_ideal = IdealCamera(n_pixels, n_pixels, pixel_size)
 smld_ideal = BasicSMLD(smld.emitters, camera_ideal, smld.n_frames, smld.n_datasets)
-images_ideal = gen_images(smld_ideal, psf, poisson_noise=true, bg=5.0)
+images_ideal, _ = gen_images(smld_ideal, psf, poisson_noise=true, bg=5.0)
 
 # Create video
 println("\nCreating video...")

--- a/dev/stack_viewer.jl
+++ b/dev/stack_viewer.jl
@@ -22,9 +22,9 @@ img_stack = rand(Float32, 512, 512, 100)
 view_stack(img_stack)
 
 # Example with SMLM image data
-using SMLMSim
-psf = MicroscopePSFs.GaussianPSF(0.15)  # 150nm PSF width
-images = gen_image_sequence(psf, systems)
+using SMLMSim, MicroscopePSFs
+smld, _ = simulate(DiffusionSMLMConfig(density=0.5, box_size=5.0))
+images, _ = gen_images(smld, GaussianPSF(0.15))  # 150nm PSF width
 view_stack(images)
 ```
 """

--- a/dev/test_README.jl
+++ b/dev/test_README.jl
@@ -1,156 +1,156 @@
-# using Pkg
-# Pkg.activate("dev")
+# test_README.jl - Executable mirror of the code examples in README.md.
+#
+# Run this to verify the README's examples work against the current API
+# (v0.7.0: *Config parameter objects + 2-tuple `simulate`/`gen_images` returns).
+# Uses CairoMakie (headless-friendly) for the visualization example.
 
+using Pkg
+Pkg.activate(@__DIR__)
 using Revise
+
 using SMLMSim
-using CairoMakie
 using MicroscopePSFs
+using CairoMakie
+using Statistics
+
 #==========================================================================
-Basic Usage
+Quick Start: Static SMLM Simulation
 ==========================================================================#
 
-# Basic simulation with default parameters
-camera = IdealCamera(1:128, 1:128, 0.1)  # 128×128 pixels, 100nm pixels
-smld_true, smld_model, smld_noisy = simulate(
+camera = IdealCamera(128, 128, 0.1)                   # 128×128 pixels, 100nm pixels
+params = StaticSMLMConfig(density=1.0, σ_psf=0.13)    # density 1/μm², PSF 130nm
+
+smld_noisy, info = simulate(
+    params;                                           # ';' separates positional from keyword args
+    pattern=Nmer2D(n=8, d=0.1),                       # 100nm diameter ring
     camera=camera
 )
-
-# More customized simulation
-smld_true, smld_model, smld_noisy = simulate(;
-    ρ=1.0,                # emitters per μm²
-    σ_psf=0.13,           # PSF width in μm (130nm)
-    minphotons=50,        # minimum photons for detection
-    ndatasets=10,         # number of independent datasets
-    nframes=1000,         # frames per dataset
-    framerate=50.0,       # frames per second
-    pattern=Nmer2D(n=6, d=0.2),  # hexamer with 200nm diameter
-    molecule=GenericFluor(photons=1e5, k_off=50.0, k_on=1e-2),  # rates in 1/s
-    camera=IdealCamera(1:256, 1:128, 0.1)  # pixelsize in μm
-)
+# info.smld_true and info.smld_model hold the intermediate results
+println("Static: generated $(length(smld_noisy.emitters)) localizations.")
 
 #==========================================================================
-Pattern Types
+Quick Start: Diffusion & Interaction Simulation
 ==========================================================================#
 
-# 2D Patterns
-# N molecules arranged in a circle
-nmer = Nmer2D(n=8, d=0.1)  # 8 molecules in a 100nm diameter circle
-
-# Linear pattern with random positions
-line = Line2D(λ=5.0, endpoints=[(-2.0, 0.0), (2.0, 0.0)])  # 5 molecules per μm along line
-
-# 3D Patterns
-# N molecules arranged in a circle at z=0
-nmer3d = Nmer3D(n=8, d=0.1)  # 8 molecules in a 100nm diameter circle
-
-# 3D line with random positions
-line3d = Line3D(λ=5.0, endpoints=[(-1.0, 0.0, -0.5), (1.0, 0.0, 0.5)])
+diff_params = DiffusionSMLMConfig(
+    density = 0.5,           # molecules per μm²
+    box_size = 10.0,         # μm
+    diff_monomer = 0.1,      # μm²/s
+    k_off = 0.2,             # s⁻¹ dimer dissociation rate
+    dt = 0.01,               # s simulation timestep
+    t_max = 10.0,            # s total simulation time
+    camera_framerate = 10.0, # 10 fps (100ms per frame)
+    camera_exposure = 0.1    # 100ms exposure integrates 10 timesteps per frame
+)
+smld_diff, diff_info = simulate(diff_params)          # returns (BasicSMLD, SimInfo)
+println("Diffusion: simulated $(diff_params.t_max) s -> $(smld_diff.n_frames) frames.")
 
 #==========================================================================
-Molecule Models
+Patterns
 ==========================================================================#
 
-# Generic fluorophore with two-state kinetics
-fluor = GenericFluor(
-    photons=10000.0,     # photon emission rate in Hz
-    k_off=10.0,          # off rate in Hz (state 1 → state 2)
-    k_on=1e-2            # on rate in Hz (state 2 → state 1)
-)
+nmer = Nmer2D(n=8, d=0.1)                             # 8 molecules in a 100nm circle
+line = Line3D(λ=5.0, endpoints=[(-1.0, 0.0, -0.5), (1.0, 0.0, 0.5)])  # 5 mols/μm
 
 #==========================================================================
-Diffusion and Interaction Simulation
+Labeling
 ==========================================================================#
 
-# Set up parameters for diffusion simulation using Smoluchowski dynamics
-params = DiffusionSMLMParams(
-    density = 0.5,        # molecules per μm²
-    box_size = 10.0,      # μm
-    diff_monomer = 0.1,   # μm²/s
-    diff_dimer = 0.05,    # μm²/s
-    k_off = 0.2,          # s⁻¹
-    r_react = 0.01,       # μm
-    d_dimer = 0.05,       # μm
-    dt = 0.01,            # s
-    t_max = 10.0          # s
-)
+labeling = FixedLabeling()                            # exactly 1 fluorophore per site
+labeling = PoissonLabeling(1.5)                       # Poisson, avg 1.5 per site
+labeling = BinomialLabeling(4, 0.8)                   # 4 attachment points, 80% each
+labeling = PoissonLabeling(1.5; efficiency=0.9)       # 90% of sites get labeled
 
-# Run simulation
-systems = simulate(params)
-
-# Visualize the simulation
-visualize_sequence(systems, filename="diffusion.mp4", framerate=round(Int64,1/params.dt))
-
-# Generate microscope images
-psf = GaussianPSF(0.15)  # 150nm PSF width
-images = gen_image_sequence(
-    psf, 
-    systems,
-    frame_integration=10
-)
-
-# Extract only dimers
-dimer_systems = get_dimers(systems)
-dimer_images = gen_image_sequence(
-    psf, 
-    dimer_systems, 
-    frame_integration=10
-)
+smld_lab, _ = simulate(params; pattern=Nmer2D(), labeling=PoissonLabeling(1.5))
+println("Labeling: $(length(smld_lab.emitters)) localizations with Poisson labeling.")
 
 #==========================================================================
-2D Simulation with Visualization
+Molecules & Photophysics
 ==========================================================================#
 
-# Create camera with physical pixel size
-camera_viz = IdealCamera(1:128, 1:256, 0.1)  # 128×256 pixels, 100nm pixels
+# Two-state blinking model using the positional rate-matrix constructor
+fluor = GenericFluor(10000.0, [-10.0 10.0; 1e-2 -1e-2])  # γ=1e4, k_off=10, k_on=1e-2
 
-# Simulation parameters in physical units
-smld_true_viz, smld_model_viz, smld_noisy_viz = simulate(;
-    ρ=1.0,                # emitters per μm²
-    σ_psf=0.13,           # PSF width in μm
-    pattern=Nmer2D(n=6, d=0.2),  # hexamer with 200nm diameter
+#==========================================================================
+Image Generation
+==========================================================================#
+
+psf = GaussianPSF(0.15)                               # 150nm PSF width
+images, img_info = gen_images(smld_diff, psf;
+    support=1.0,                                      # PSF support radius in μm (faster)
+    poisson_noise=true                                # add shot noise
+)
+println("Image generation: $(img_info.frames_generated) images, stack size $(size(images)).")
+
+#==========================================================================
+sCMOS Camera with Realistic Noise
+==========================================================================#
+
+# sCMOS camera (128×128 pixels, 100nm pixels, 1.6 e⁻ read noise)
+camera_scmos = SCMOSCamera(128, 128, 0.1, 1.6)
+smld_scmos, _ = simulate(params;
+    pattern=Nmer2D(n=8, d=0.1),
+    camera=camera_scmos
+)
+# Full sCMOS noise model: QE, Poisson, read noise, gain, offset
+images_scmos, _ = gen_images(smld_scmos, GaussianPSF(0.15); bg=10.0, camera_noise=true)
+println("sCMOS static images: size $(size(images_scmos)).")
+
+# For diffusion simulations
+diff_scmos_params = DiffusionSMLMConfig(density=0.5, box_size=10.0)
+smld_diff_scmos, _ = simulate(diff_scmos_params; camera=camera_scmos, override_count=10)
+println("sCMOS diffusion: $(length(smld_diff_scmos.emitters)) emitters across all frames.")
+
+#==========================================================================
+Example Workflow: Static Simulation & Visualization
+==========================================================================#
+
+camera_viz = IdealCamera(128, 128, 0.1)
+params_viz = StaticSMLMConfig(density=1.0, σ_psf=0.13)
+smld_viz, _ = simulate(
+    params_viz;
+    pattern=Nmer2D(n=6, d=0.2),                       # hexamer
     camera=camera_viz
 )
 
-# Extract coordinates from emitters
-x_noisy = [e.x for e in smld_noisy_viz.emitters]
-y_noisy = [e.y for e in smld_noisy_viz.emitters]
-photons = [e.photons for e in smld_noisy_viz.emitters]
+emitters = smld_viz.emitters
+x_coords = [e.x for e in emitters]
+y_coords = [e.y for e in emitters]
+photons  = [e.photons for e in emitters]
 
-# Create figure and plot results
-fig = Figure(size=(800, 600))
-ax = Axis(fig[1, 1], 
-    title="Simulated SMLM Localizations",
-    xlabel="x (μm)",
-    ylabel="y (μm)",
-    aspect=DataAspect(),
-    yreversed=true  # This makes (0,0) at top-left
+fig = Figure(size=(600, 500))
+ax = Axis(fig[1, 1],
+    title="Simulated SMLM Localizations (Hexamer)",
+    xlabel="x (μm)", ylabel="y (μm)",
+    aspect=DataAspect(), yreversed=true
 )
-
-# Scatter plot with photon counts as color
-scatter!(ax, x_noisy, y_noisy, 
-    color=photons,
-    colormap=:viridis,
-    markersize=4,
-    alpha=0.6
-)
-
+scatter!(ax, x_coords, y_coords, color=photons, colormap=:viridis, markersize=4, alpha=0.7)
 Colorbar(fig[1, 2], colormap=:viridis, label="Photons")
-
-# Show or save the figure
 display(fig)
-# save("smlm_simulation.png", fig)
+# save("smlm_hexamer.png", fig)
 
 #==========================================================================
-3D Simulation
+Example Workflow: Diffusion with Realistic sCMOS Noise
 ==========================================================================#
 
-# Create camera with physical pixel size
-camera_3d = IdealCamera(1:128, 1:256, 0.1)  # 128×256 pixels, 100nm pixels
-
-# Simulation parameters in physical units
-smld_true_3d, smld_model_3d, smld_noisy_3d = simulate(;
-    ρ=0.5,                # emitters per μm²
-    pattern=Nmer3D(n=8, d=0.3),  # 3D pattern
-    camera=camera_3d,
-    zrange=[-2.0, 2.0]    # 4μm axial range
+camera_scmos2 = SCMOSCamera(64, 64, 0.1, 1.6)         # 64×64 pixels, 100nm/px, 1.6 e⁻
+params_spt = DiffusionSMLMConfig(
+    density = 1.0,            # 1 molecule/μm²
+    box_size = 6.4,           # 6.4×6.4 μm field
+    diff_monomer = 0.1,       # 0.1 μm²/s diffusion
+    t_max = 0.5,              # 0.5 second total
+    camera_framerate = 100.0  # 100 fps
 )
+smld_spt, _ = simulate(params_spt; camera=camera_scmos2, photons=200.0)
+
+# sCMOS images vs ideal-camera images for the same data
+images_spt_scmos, _ = gen_images(smld_spt, GaussianPSF(0.13); bg=10.0, camera_noise=true)
+
+camera_ideal = IdealCamera(64, 64, 0.1)
+smld_spt_ideal = BasicSMLD(smld_spt.emitters, camera_ideal, smld_spt.n_frames, smld_spt.n_datasets)
+images_spt_ideal, _ = gen_images(smld_spt_ideal, GaussianPSF(0.13); bg=10.0, poisson_noise=true)
+
+println("sCMOS: mean=$(round(mean(images_spt_scmos), digits=1)) ADU, std=$(round(std(images_spt_scmos), digits=1))")
+println("Ideal: mean=$(round(mean(images_spt_ideal), digits=1)) photons, std=$(round(std(images_spt_ideal), digits=1))")
+
+println("\nAll README examples executed successfully.")

--- a/dev/test_diffusion.jl
+++ b/dev/test_diffusion.jl
@@ -16,7 +16,7 @@ println("Setting up diffusion simulation parameters...")
 # Create simulation parameters
 temporal_sampling = 10
 frame_rate = 100.0
-params = DiffusionSMLMParams(
+params = DiffusionSMLMConfig(
     density = 1.0,        # molecules per μm²
     box_size = 5.0,       # 5μm box 
     diff_monomer = 0.1,   # Diffusion coefficient for monomers (μm²/s)
@@ -40,8 +40,9 @@ println("- Reaction parameters: r_react=$(params.r_react) μm, k_off=$(params.k_
 println("- Time parameters: dt=$(params.dt) s, t_max=$(params.t_max) s")
 
 println("Running diffusion simulation...")
-systems = simulate(params)
-n_frames = length(systems)
+# simulate returns (smld, info); smld is a BasicSMLD spanning all frames
+smld, info = simulate(params)
+n_frames = smld.n_frames
 
 println("Simulation complete with $(n_frames) frames")
 
@@ -51,7 +52,7 @@ psf = GaussianPSF(0.13)  # 130nm PSF width
 
 # Generate camera images
 println("Generating camera images...")
-images = gen_images(systems, psf;
+images, _ = gen_images(smld, psf;
     support=1.0,  # PSF support radius in μm
     bg=2.0,             # Background photons
     poisson_noise=true   # Add realistic Poisson noise
@@ -63,9 +64,9 @@ println("Image stack generated with size: $(size(images))")
 println("Launching stack viewer...")
 fig1 = view_stack(images, title="SMLM 2D Simulation (Hexamer Pattern)")
 
-# Show dimers only 
-system_dimers = get_dimers(systems)
-images_dimers = gen_images(system_dimers, psf;
+# Show dimers only
+smld_dimers = get_dimers(smld)
+images_dimers, _ = gen_images(smld_dimers, psf;
     support=1.0,  # PSF support radius in μm
     bg=2.0,             # Background photons
     poisson_noise=true   # Add realistic Poisson noise
@@ -73,15 +74,15 @@ images_dimers = gen_images(system_dimers, psf;
 fig2 = view_stack(images_dimers, title="SMLM 2D Simulation (Hexamer Pattern)")
 
 # Show monomers only
-system_monomers = get_monomers(systems)
-images_monomers = gen_images(system_monomers, psf;
+smld_monomers = get_monomers(smld)
+images_monomers, _ = gen_images(smld_monomers, psf;
     support=1.0,  # PSF support radius in μm
     bg=2.0,             # Background photons
     poisson_noise=true   # Add realistic Poisson noise
 )
 fig3 = view_stack(images_monomers, title="SMLM 2D Simulation (Hexamer Pattern)")
 
-dimer_lifetime = analyze_dimer_lifetime(systems)
+dimer_lifetime = analyze_dimer_lifetime(smld)
 println("Dimer lifetime: $(dimer_lifetime)")
 
 

--- a/dev/test_smlm2d.jl
+++ b/dev/test_smlm2d.jl
@@ -21,7 +21,7 @@ camera = IdealCamera(1:256, 1:256, pixelsize)
 pattern = Nmer2D(n=6, d=0.2)  # 6 molecules in a 200nm circle
 
 # Create static SMLM parameters
-params = StaticSMLMParams(
+params = StaticSMLMConfig(
     density=1.0,           # 1 pattern per square micron
     σ_psf=0.13,      # 130nm PSF width (realistic for visible light)
     minphotons=50,   # Default minimum photon count for detection
@@ -59,12 +59,15 @@ fluor = GenericFluor(
 )
 
 # Run simulation with custom pattern and fluorophore model
-smld_true, smld_model, smld_noisy = simulate(
+# simulate returns (smld_noisy, info); intermediate results live on info
+smld_noisy, info = simulate(
     params;
     pattern=pattern,
     molecule=fluor,
     camera=camera
 )
+smld_true = info.smld_true
+smld_model = info.smld_model
 
 println("SMLM simulation complete")
 println("- True emitters: $(length(smld_true.emitters))")
@@ -97,7 +100,7 @@ psf = MicroscopePSFs.GaussianPSF(0.13)  # 130nm PSF width
 
 # Generate camera images
 println("Generating camera images...")
-images = gen_images(smld_noisy, psf;
+images, _ = gen_images(smld_noisy, psf;
     support=1.0,  # PSF support radius in μm
     bg=2.0,             # Background photons
     poisson_noise=true   # Add realistic Poisson noise

--- a/dev/test_smlm3d.jl
+++ b/dev/test_smlm3d.jl
@@ -20,7 +20,7 @@ camera = IdealCamera(1:256, 1:256, pixelsize)
 pattern = Nmer3D(n=8, d=0.3)  # 8 molecules in a 300nm circle at z=0
 
 # Create static SMLM parameters for 3D simulation
-params = StaticSMLMParams(
+params = StaticSMLMConfig(
     density = 0.5,           # 0.5 patterns per square micron (less dense than 2D example)
     σ_psf = 0.13,      # 130nm PSF width (realistic for visible light)
     minphotons = 100,  # Minimum photon count for detection
@@ -58,12 +58,15 @@ fluor = GenericFluor(
 )
 
 # Run simulation with custom pattern and fluorophore model
-smld_true, smld_model, smld_noisy = simulate(
+# simulate returns (smld_noisy, info); intermediate results live on info
+smld_noisy, info = simulate(
     params;
     pattern=pattern,
     molecule=fluor,
     camera=camera
 )
+smld_true = info.smld_true
+smld_model = info.smld_model
 
 println("3D SMLM simulation complete")
 println("- True emitters: $(length(smld_true.emitters))")
@@ -168,7 +171,7 @@ psf = SplinePSF(psf_raw, x_range, y_range, z_range)
 
 # Generate camera images
 println("Generating camera images...")
-images = gen_images(smld_noisy, psf;
+images, _ = gen_images(smld_noisy, psf;
     support=1.0,        # PSF support radius in μm
     bg=2.0,             # Background photons
     poisson_noise=true  # Add realistic Poisson noise


### PR DESCRIPTION
## Summary
Migrates the `dev/` demo scripts to the v0.7.0 API. They predated the tuple-return refactor and no longer ran as written.

## API shifts addressed
- `StaticSMLMParams`/`DiffusionSMLMParams` → `StaticSMLMConfig`/`DiffusionSMLMConfig`
- `simulate` now returns `(smld, info)`; static intermediates moved onto `info` (`info.smld_true`, `info.smld_model`)
- `gen_images` now returns `(images, img_info)`
- removed `gen_image_sequence` / `visualize_sequence`
- `Emitter2DFit` positional constructor gained `σ_xy` (switched to keyword form)
- `scmos_demo.jl` was missing `using Statistics`

## Files
`test_README.jl` (rewritten to mirror current README), `test_diffusion.jl`, `test_smlm2d.jl`, `test_smlm3d.jl`, `scmos_quick_demo.jl`, `scmos_demo.jl`, `scmos_video.jl`, `stack_viewer.jl`.

## Verification
All SMLMSim API calls probed against the package; every script parse-checked; `scmos_quick_demo.jl` run end-to-end. GLMakie/VideoIO scripts not executed headlessly (need display + instantiated dev env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
